### PR TITLE
Remove parametrized modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,11 @@ ZMQ_FLAGS=
 endif
 
 
-all: compile 
+all: compile
+
+sh:
+	@erl -pa ebin/ deps/*/ebin/ -s reloader -eval "d:err()"
+
 
 deps/v8/.git/config:
 	@git submodule init
@@ -32,13 +36,14 @@ deps/zeromq2/.git/HEAD:
 	@git submodule init
 	@git submodule update
 
-deps/v8/libv8.a: deps/v8/.git/config 
+deps/v8/libv8.a: deps/v8/.git/config
 	cd deps/v8 && $(V8ENV) scons $(V8FLAGS)
 
 deps/zeromq2/src/.libs/libzmq.a: deps/zeromq2/.git/HEAD
 	@cd deps/zeromq2 && ./autogen.sh && ./configure $(ZMQ_FLAGS) && make
 
 dependencies: deps/v8/libv8.a deps/zeromq2/src/.libs/libzmq.a
+	@./rebar get-deps
 
 test: compile
 	@./rebar eunit skip_deps=true
@@ -46,14 +51,15 @@ test: compile
 dbg-test: compile
 	@USE_GDB=true ./rebar eunit skip_deps=true
 
-compile: dependencies
-	@./rebar get-deps
+compile: dependencies fast
+
+fast:
 	@EXTRA_CFLAGS= ./rebar compile
 
 debug: dependencies
 	@EXTRA_CFLAGS="-g3 -O0 -DERLV8_DEBUG" ./rebar compile
 
-clean: 
+clean:
 	-rm c_src/*.o
 
 analyze:

--- a/c_src/erlv8_instantiate.cc
+++ b/c_src/erlv8_instantiate.cc
@@ -7,58 +7,58 @@ TickHandler(InstantiateTickHandler) {
   ERL_NIF_TERM inst_ref = enif_make_copy(ref_env, tick_ref);
   val_res_t *fun_res;
   if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&fun_res))) {
-	ERL_NIF_TERM head, tail;
-	ERL_NIF_TERM current = array[2];
-	unsigned int alen;
-	
-	enif_get_list_length(vm->env,array[2],&alen);
-	
-	v8::Local<v8::Value> *args = NULL;
-	args = new v8::Local<v8::Value>[alen];
-	int i = 0;
-	while (enif_get_list_cell(vm->env, current, &head, &tail)) {
-	  args[i] = v8::Local<v8::Value>::New(term_to_js(fun_res->ctx, vm->isolate, vm->env,head));
-	  i++; current = tail;
-	}
+    ERL_NIF_TERM head, tail;
+    ERL_NIF_TERM current = array[2];
+    unsigned int alen;
 
-	v8::Handle<v8::Function> f = v8::Handle<v8::Function>::Cast(fun_res->val);
+    enif_get_list_length(vm->env,array[2],&alen);
 
-	if (!*f->GetHiddenValue(vm->string__erlv8__)) { // js function
-	  v8::TryCatch try_catch;
-	  v8::Local<v8::Value> inst_result = f->NewInstance(alen, args);
-	  if (inst_result.IsEmpty()) {
-	    SEND(vm->server,
-		 enif_make_tuple3(env,
-				  enif_make_atom(env,"result"),
-				  enif_make_copy(env,inst_ref),
-				  enif_make_tuple2(env,
-						   enif_make_atom(env,"throw"),
-						   enif_make_tuple2(env,
-								    enif_make_atom(env,"error"),
-								    js_to_term(fun_res->ctx,vm->isolate, env,try_catch.Exception())))));
-	  } else {
-	    SEND(vm->server,
-		 enif_make_tuple3(env,
-				  enif_make_atom(env,"result"),
-				  enif_make_copy(env,inst_ref),
-				  js_to_term(fun_res->ctx,vm->isolate, env,inst_result)));
-	  }
-	} else { // native Erlang function
-	  v8::Local<v8::Array> array = v8::Array::New(alen);
-	  
-	  for (unsigned int i=0;i<alen;i++) {
-	    array->Set(i,args[i]);
-	  }
-	  
-	  ErlangConstFun(vm,
-			 external_to_term(f->GetHiddenValue(v8::String::New("__erlv8__"))), 
-			 inst_ref,
-			 vm->empty_constructor->GetFunction()->NewInstance(),
-			 array);
-	}
-	  
-	delete [] args;
-	args = NULL;
+    v8::Local<v8::Value> *args = NULL;
+    args = new v8::Local<v8::Value>[alen];
+    int i = 0;
+    while (enif_get_list_cell(vm->env, current, &head, &tail)) {
+      args[i] = v8::Local<v8::Value>::New(term_to_js(fun_res->ctx, vm->isolate, vm->env,head));
+      i++; current = tail;
+    }
+
+    v8::Handle<v8::Function> f = v8::Handle<v8::Function>::Cast(fun_res->val);
+
+    if (!*f->GetHiddenValue(vm->string__erlv8__)) { // js function
+      v8::TryCatch try_catch;
+      v8::Local<v8::Value> inst_result = f->NewInstance(alen, args);
+      if (inst_result.IsEmpty()) {
+        SEND(vm->server,
+             enif_make_tuple3(env,
+                              enif_make_atom(env,"result"),
+                              enif_make_copy(env,inst_ref),
+                              enif_make_tuple2(env,
+                                               enif_make_atom(env,"throw"),
+                                               enif_make_tuple2(env,
+                                                                enif_make_atom(env,"error"),
+                                                                js_to_term(fun_res->ctx,vm->isolate, env,try_catch.Exception())))));
+      } else {
+        SEND(vm->server,
+             enif_make_tuple3(env,
+                              enif_make_atom(env,"result"),
+                              enif_make_copy(env,inst_ref),
+                              js_to_term(fun_res->ctx,vm->isolate, env,inst_result)));
+      }
+    } else { // native Erlang function
+      v8::Local<v8::Array> array = v8::Array::New(alen);
+
+      for (unsigned int i=0;i<alen;i++) {
+        array->Set(i,args[i]);
+      }
+
+      ErlangConstFun(vm,
+                     external_to_term(f->GetHiddenValue(v8::String::New("__erlv8__"))),
+                     inst_ref,
+                     vm->empty_constructor->GetFunction()->NewInstance(),
+                     array);
+    }
+
+    delete [] args;
+    args = NULL;
   }
   enif_free_env(ref_env);
   TickHandlerResolution result;
@@ -68,7 +68,7 @@ TickHandler(InstantiateTickHandler) {
 
 void ErlangConstFun(VM * vm, ERL_NIF_TERM term, ERL_NIF_TERM ref, v8::Handle<v8::Object> instance, v8::Handle<v8::Array> array) {
   v8::HandleScope handle_scope;
- 
+
   ctx_res_t *ptr = (ctx_res_t *)enif_alloc_resource(ctx_resource, sizeof(ctx_res_t));
   ptr->ctx = v8::Persistent<v8::Context>::New(v8::Context::GetCurrent());
   // prepare arguments
@@ -81,17 +81,16 @@ void ErlangConstFun(VM * vm, ERL_NIF_TERM term, ERL_NIF_TERM ref, v8::Handle<v8:
   // send invocation request
   SEND(vm->server,
        enif_make_tuple3(env,
-			enif_make_copy(env,term),
-			enif_make_tuple7(env, 
-					 enif_make_atom(env,"erlv8_fun_invocation"),
-					 enif_make_atom(env, "true"),
-					 js_to_term(vm->context, vm->isolate, env, instance), // FIXME: not quite sure it's right
-					 js_to_term(vm->context, vm->isolate, env, instance),
-					 enif_make_copy(env, ref),
-					 enif_make_pid(env, vm->server),
-					 enif_make_resource(env, ptr)
-					 ),
-			enif_make_copy(env,arglist)));
+                        enif_make_copy(env,term),
+                        enif_make_tuple7(env,
+                                         enif_make_atom(env,"erlv8_fun_invocation"),
+                                         enif_make_atom(env, "true"),
+                                         js_to_term(vm->context, vm->isolate, env, instance), // FIXME: not quite sure it's right
+                                         js_to_term(vm->context, vm->isolate, env, instance),
+                                         enif_make_copy(env, ref),
+                                         enif_make_pid(env, vm->server),
+                                         enif_make_resource(env, ptr)
+                                         ),
+                        enif_make_copy(env,arglist)));
   enif_release_resource(ptr);
 };
-

--- a/c_src/erlv8_set.cc
+++ b/c_src/erlv8_set.cc
@@ -1,252 +1,254 @@
 #include "erlv8.hh"
 
 TickHandler(SetTickHandler) {
-  ErlNifEnv *tmp_env = enif_alloc_env();
-  ERL_NIF_TERM value = enif_make_copy(tmp_env, array[3]); // stashing it away since Set() might call an accessor, which might change vm->env
-  val_res_t *obj_res;
-  if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
-	LHCS(vm->isolate, obj_res->ctx);
+    ErlNifEnv *tmp_env = enif_alloc_env();
+    ERL_NIF_TERM value = enif_make_copy(tmp_env, array[3]); // stashing it away since Set() might call an accessor, which might change vm->env
+    val_res_t *obj_res;
+    if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
+        LHCS(vm->isolate, obj_res->ctx);
 
-	v8::PropertyAttribute property_attribute = v8::None;
+        v8::PropertyAttribute property_attribute = v8::None;
 
-	if (arity == 5) {
-	  property_attribute = term_to_property_attribute(vm->env,array[4]);
-	}
-	
-	obj_res->val->ToObject()->Set(term_to_js(obj_res->ctx, vm->isolate, vm->env,array[2]),term_to_js(obj_res->ctx, vm->isolate, tmp_env,value), property_attribute);
-	
-	SEND(vm->server,
-		 enif_make_tuple3(env,
-				  enif_make_atom(env,"result"),
-				  enif_make_copy(env,tick_ref),
-				  enif_make_copy(env,value)));
-  } 
-  enif_free_env(tmp_env);
-  TickHandlerResolution result;
-  result.type = DONE;
-  return result;
+        if (arity == 5) {
+            property_attribute = term_to_property_attribute(vm->env,array[4]);
+        }
+
+        obj_res->val->ToObject()->Set(term_to_js(obj_res->ctx, vm->isolate, vm->env,array[2]),
+                                      term_to_js(obj_res->ctx, vm->isolate, tmp_env,value),
+                                      property_attribute);
+
+        SEND(vm->server,
+             enif_make_tuple3(env,
+                              enif_make_atom(env,"result"),
+                              enif_make_copy(env,tick_ref),
+                              enif_make_copy(env,value)));
+    }
+    enif_free_env(tmp_env);
+    TickHandlerResolution result;
+    result.type = DONE;
+    return result;
 }
 
 TickHandler(SetProtoTickHandler) {
-  val_res_t *obj_res;
-  if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
-	LHCS(vm->isolate, obj_res->ctx);
+    val_res_t *obj_res;
+    if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
+        LHCS(vm->isolate, obj_res->ctx);
 
-    const char *atom_val = obj_res->val->ToObject()->SetPrototype(term_to_js(obj_res->ctx,vm->isolate,vm->env,array[2])) ? "true" : "false";
-	
-	SEND(vm->server,
-		 enif_make_tuple3(env,
-						  enif_make_atom(env,"result"),
-						  enif_make_copy(env,tick_ref),
-						  enif_make_atom(env,atom_val)));
-  } 
-  TickHandlerResolution result;
-  result.type = DONE;
-  return result;
+        const char *atom_val = obj_res->val->ToObject()->SetPrototype(term_to_js(obj_res->ctx,vm->isolate,vm->env,array[2])) ? "true" : "false";
+
+        SEND(vm->server,
+             enif_make_tuple3(env,
+                              enif_make_atom(env,"result"),
+                              enif_make_copy(env,tick_ref),
+                              enif_make_atom(env,atom_val)));
+    }
+    TickHandlerResolution result;
+    result.type = DONE;
+    return result;
 }
 
 TickHandler(SetHiddenTickHandler) {
-  val_res_t *obj_res;
-  if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
-	LHCS(vm->isolate, obj_res->ctx);
+    val_res_t *obj_res;
+    if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
+        LHCS(vm->isolate, obj_res->ctx);
 
-	obj_res->val->ToObject()->SetHiddenValue(term_to_js(obj_res->ctx, vm->isolate, vm->env,array[2])->ToString(),term_to_js(obj_res->ctx,vm->isolate, vm->env,array[3]));
-	
-	SEND(vm->server,
-	     enif_make_tuple3(env,
-			      enif_make_atom(env,"result"),
-			      enif_make_copy(env,tick_ref),
-			      enif_make_copy(env,array[2])));
-  } 
-  TickHandlerResolution result;
-  result.type = DONE;
-  return result;
+        obj_res->val->ToObject()->SetHiddenValue(term_to_js(obj_res->ctx, vm->isolate, vm->env,array[2])->ToString(),term_to_js(obj_res->ctx,vm->isolate, vm->env,array[3]));
+
+        SEND(vm->server,
+             enif_make_tuple3(env,
+                              enif_make_atom(env,"result"),
+                              enif_make_copy(env,tick_ref),
+                              enif_make_copy(env,array[2])));
+    }
+    TickHandlerResolution result;
+    result.type = DONE;
+    return result;
 }
 
 TickHandler(SetInternalTickHandler) {
-  val_res_t *obj_res;
-  char name[MAX_ATOM_LEN];
-  unsigned len;
+    val_res_t *obj_res;
+    char name[MAX_ATOM_LEN];
+    unsigned len;
 
-  if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
-	LHCS(vm->isolate, obj_res->ctx);
+    if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
+        LHCS(vm->isolate, obj_res->ctx);
 
-	int index;
-	enif_get_int(vm->env, array[2], &index);
+        int index;
+        enif_get_int(vm->env, array[2], &index);
 
-	if (index < 0 || (index + 1 > obj_res->val->ToObject()->InternalFieldCount())) {
-	  		SEND(vm->server,
-			 enif_make_tuple3(env,
-							  enif_make_atom(env,"result"),
-							  enif_make_copy(env,tick_ref),
-							  enif_make_atom(env,"error")));
-	} else {
+        if (index < 0 || (index + 1 > obj_res->val->ToObject()->InternalFieldCount())) {
+            SEND(vm->server,
+                 enif_make_tuple3(env,
+                                  enif_make_atom(env,"result"),
+                                  enif_make_copy(env,tick_ref),
+                                  enif_make_atom(env,"error")));
+        } else {
 
-	  if (!strcmp(tick_name,"set_internal_extern")) {
-		enif_get_atom_length(vm->env, array[4], &len, ERL_NIF_LATIN1);
-		enif_get_atom(vm->env,array[4],(char *)&name,len + 1, ERL_NIF_LATIN1);
-		v8::Handle<v8::Object> proto = extern_name_to_proto(vm, name);
-		obj_res->val->ToObject()->SetInternalField(index,term_to_external(array[3]));
-	  } else {
-		obj_res->val->ToObject()->SetInternalField(index,term_to_js(obj_res->ctx,vm->isolate, vm->env,array[3]));
-	  }
-	  
-	  SEND(vm->server,
-		   enif_make_tuple3(env,
-							enif_make_atom(env,"result"),
-							enif_make_copy(env,tick_ref),
-						  enif_make_copy(env,array[3])));
-	} 
-  }
-  TickHandlerResolution result;
-  result.type = DONE;
-  return result;
+            if (!strcmp(tick_name,"set_internal_extern")) {
+                enif_get_atom_length(vm->env, array[4], &len, ERL_NIF_LATIN1);
+                enif_get_atom(vm->env,array[4],(char *)&name,len + 1, ERL_NIF_LATIN1);
+                v8::Handle<v8::Object> proto = extern_name_to_proto(vm, name);
+                obj_res->val->ToObject()->SetInternalField(index,term_to_external(array[3]));
+            } else {
+                obj_res->val->ToObject()->SetInternalField(index,term_to_js(obj_res->ctx,vm->isolate, vm->env,array[3]));
+            }
+
+            SEND(vm->server,
+                 enif_make_tuple3(env,
+                                  enif_make_atom(env,"result"),
+                                  enif_make_copy(env,tick_ref),
+                                  enif_make_copy(env,array[3])));
+        }
+    }
+    TickHandlerResolution result;
+    result.type = DONE;
+    return result;
 }
 
 v8::Handle<v8::Value> GetterFun(v8::Local<v8::String> property,const v8::AccessorInfo &info); // fwd
 void SetterFun(v8::Local<v8::String> property,v8::Local<v8::Value> value,const v8::AccessorInfo &info); // fwd
 
 void weak_accessor_data_cleaner(v8::Persistent<v8::Value> object, void * data) {
-  if (object.IsNearDeath()) {
-	object->ToObject()->DeleteHiddenValue(v8::String::New("_getter"));
-	object->ToObject()->DeleteHiddenValue(v8::String::New("_setter"));
+    if (object.IsNearDeath()) {
+        object->ToObject()->DeleteHiddenValue(v8::String::New("_getter"));
+        object->ToObject()->DeleteHiddenValue(v8::String::New("_setter"));
         object.Dispose();
         object.Clear();
-  }
+    }
 }
 
 TickHandler(SetAccessorTickHandler) {
-  char aname[MAX_ATOM_LEN];
-  const char *atom_val;
-  val_res_t *obj_res;
-  if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
-	LHCS(vm->isolate, obj_res->ctx);
+    char aname[MAX_ATOM_LEN];
+    const char *atom_val;
+    val_res_t *obj_res;
+    if (enif_get_resource(vm->env,array[1],val_resource,(void **)(&obj_res))) {
+        LHCS(vm->isolate, obj_res->ctx);
 
-	if (arity > 3) {
-	  v8::Handle<v8::Value> name = term_to_js(obj_res->ctx,vm->isolate, vm->env,array[2]);
-	  if (!name->IsString()) {
-          goto badarg;
-      }
-	  v8::AccessorGetter getter = GetterFun;
-	  v8::AccessorSetter setter = 0;
-	  v8::Persistent<v8::Object> data = v8::Persistent<v8::Object>::New(v8::Object::New());
-	  data.MakeWeak(NULL,weak_accessor_data_cleaner); // so that we'll release externals when we're done
+        if (arity > 3) {
+            v8::Handle<v8::Value> name = term_to_js(obj_res->ctx,vm->isolate, vm->env,array[2]);
+            if (!name->IsString()) {
+                goto badarg;
+            }
+            v8::AccessorGetter getter = GetterFun;
+            v8::AccessorSetter setter = 0;
+            v8::Persistent<v8::Object> data = v8::Persistent<v8::Object>::New(v8::Object::New());
+            data.MakeWeak(NULL,weak_accessor_data_cleaner); // so that we'll release externals when we're done
 
-	  if (term_to_js(obj_res->ctx,vm->isolate, vm->env,array[3])->IsUndefined()) {
-          goto badarg;
-	  } else {
-		data->SetHiddenValue(v8::String::New("_getter"), term_to_external(array[3]));
-	  }
+            if (term_to_js(obj_res->ctx,vm->isolate, vm->env,array[3])->IsUndefined()) {
+                goto badarg;
+            } else {
+                data->SetHiddenValue(v8::String::New("_getter"), term_to_external(array[3]));
+            }
 
-	  if (arity > 4) {
-		setter = SetterFun;
-		data->SetHiddenValue(v8::String::New("_setter"), term_to_external(array[4]));
-	  }
+            if (arity > 4) {
+                setter = SetterFun;
+                data->SetHiddenValue(v8::String::New("_setter"), term_to_external(array[4]));
+            }
 
-	  v8::AccessControl access_control = v8::DEFAULT;
-   
-	  if (arity > 5 && enif_is_atom(vm->env, array[5])) {
-		unsigned len;
-		enif_get_atom_length(vm->env, array[5], &len, ERL_NIF_LATIN1);
-		enif_get_atom(vm->env,array[5], (char *) &aname,len + 1, ERL_NIF_LATIN1);
-		if (!strcmp(aname,"default")) {
-		  access_control = v8::DEFAULT;
-		} else if (!strcmp(aname,"all_can_read")) {
-		  access_control = v8::ALL_CAN_READ;
-		} else if (!strcmp(aname,"all_can_write")) {
-		  access_control = v8::ALL_CAN_WRITE;
-		} else if (!strcmp(aname,"prohibits_overwriting")) {
-		  access_control = v8::PROHIBITS_OVERWRITING;
-		}
-	  }
+            v8::AccessControl access_control = v8::DEFAULT;
 
-	  v8::PropertyAttribute property_attribute = v8::None;
-   
-	  if (arity > 6) {
-		property_attribute = term_to_property_attribute(vm->env,array[6]);
-	  }
+            if (arity > 5 && enif_is_atom(vm->env, array[5])) {
+                unsigned len;
+                enif_get_atom_length(vm->env, array[5], &len, ERL_NIF_LATIN1);
+                enif_get_atom(vm->env,array[5], (char *) &aname,len + 1, ERL_NIF_LATIN1);
+                if (!strcmp(aname,"default")) {
+                    access_control = v8::DEFAULT;
+                } else if (!strcmp(aname,"all_can_read")) {
+                    access_control = v8::ALL_CAN_READ;
+                } else if (!strcmp(aname,"all_can_write")) {
+                    access_control = v8::ALL_CAN_WRITE;
+                } else if (!strcmp(aname,"prohibits_overwriting")) {
+                    access_control = v8::PROHIBITS_OVERWRITING;
+                }
+            }
 
-      atom_val = obj_res->val->ToObject()->SetAccessor(name->ToString(), getter, setter, data,
-																   access_control, property_attribute) ? "true" : "false";
-      goto send;
-	}
-badarg:
-    atom_val = "badarg";
-send:
-	SEND(vm->server,
-		 enif_make_tuple3(env,
-						  enif_make_atom(env,"result"),
-						  enif_make_copy(env,tick_ref),
-						  enif_make_atom(env, atom_val)));
-  } 
-  TickHandlerResolution result;
-  result.type = DONE;
-  return result;
+            v8::PropertyAttribute property_attribute = v8::None;
+
+            if (arity > 6) {
+                property_attribute = term_to_property_attribute(vm->env,array[6]);
+            }
+
+            atom_val = obj_res->val->ToObject()->SetAccessor(name->ToString(), getter, setter, data,
+                                                             access_control, property_attribute) ? "true" : "false";
+            goto send;
+        }
+    badarg:
+        atom_val = "badarg";
+    send:
+        SEND(vm->server,
+             enif_make_tuple3(env,
+                              enif_make_atom(env,"result"),
+                              enif_make_copy(env,tick_ref),
+                              enif_make_atom(env, atom_val)));
+    }
+    TickHandlerResolution result;
+    result.type = DONE;
+    return result;
 }
 
 
 
 v8::Handle<v8::Value> GetterFun(v8::Local<v8::String> property,const v8::AccessorInfo &info) {
-  v8::HandleScope handle_scope;
-  VM * vm = (VM *)__ERLV8__(v8::Context::GetCurrent()->Global());
+    v8::HandleScope handle_scope;
+    VM * vm = (VM *)__ERLV8__(v8::Context::GetCurrent()->Global());
 
-  v8::Local<v8::Object> data = info.Data()->ToObject();
-  
-  // each call gets a unique ref
-  ERL_NIF_TERM ref = enif_make_ref(vm->env);
+    v8::Local<v8::Object> data = info.Data()->ToObject();
 
-  // prepare arguments
-  ERL_NIF_TERM *arr = (ERL_NIF_TERM *) malloc(sizeof(ERL_NIF_TERM) * 1);
-  arr[0] = js_to_term(vm->context, vm->isolate, vm->env, property);
-  ERL_NIF_TERM arglist = enif_make_list_from_array(vm->env,arr,1);
-  free(arr);
+    // each call gets a unique ref
+    ERL_NIF_TERM ref = enif_make_ref(vm->env);
 
-  // send invocation request
-  SEND(vm->server,
-	   enif_make_tuple3(env,
-						enif_make_copy(env,external_to_term(data->GetHiddenValue(v8::String::New("_getter")))),
-						enif_make_tuple7(env, 
-										 enif_make_atom(env,"erlv8_fun_invocation"),
-										 enif_make_atom(env,"false"),
-										 js_to_term(vm->context, vm->isolate, env, info.Holder()),
-										 js_to_term(vm->context, vm->isolate, env, info.This()),
-										 enif_make_copy(env, ref),
-										 enif_make_pid(env, vm->server),
-										 enif_make_copy(env, external_to_term(v8::Context::GetCurrent()->Global()->GetHiddenValue(v8::String::New("__erlv8__ctx__"))))
-										 ),
-						enif_make_copy(env,arglist)));
-  return handle_scope.Close(vm->ticker(ref));  
+    // prepare arguments
+    ERL_NIF_TERM *arr = (ERL_NIF_TERM *) malloc(sizeof(ERL_NIF_TERM) * 1);
+    arr[0] = js_to_term(vm->context, vm->isolate, vm->env, property);
+    ERL_NIF_TERM arglist = enif_make_list_from_array(vm->env,arr,1);
+    free(arr);
+
+    // send invocation request
+    SEND(vm->server,
+         enif_make_tuple3(env,
+                          enif_make_copy(env,external_to_term(data->GetHiddenValue(v8::String::New("_getter")))),
+                          enif_make_tuple7(env,
+                                           enif_make_atom(env,"erlv8_fun_invocation"),
+                                           enif_make_atom(env,"false"),
+                                           js_to_term(vm->context, vm->isolate, env, info.Holder()),
+                                           js_to_term(vm->context, vm->isolate, env, info.This()),
+                                           enif_make_copy(env, ref),
+                                           enif_make_pid(env, vm->server),
+                                           enif_make_copy(env, external_to_term(v8::Context::GetCurrent()->Global()->GetHiddenValue(v8::String::New("__erlv8__ctx__"))))
+                                           ),
+                          enif_make_copy(env,arglist)));
+    return handle_scope.Close(vm->ticker(ref));
 }
 
 void SetterFun(v8::Local<v8::String> property,v8::Local<v8::Value> value,const v8::AccessorInfo &info) {
-  v8::HandleScope handle_scope;
-  VM * vm = (VM *)__ERLV8__(v8::Context::GetCurrent()->Global());
+    v8::HandleScope handle_scope;
+    VM * vm = (VM *)__ERLV8__(v8::Context::GetCurrent()->Global());
 
-  v8::Local<v8::Object> data = info.Data()->ToObject();
+    v8::Local<v8::Object> data = info.Data()->ToObject();
 
-  // each call gets a unique ref
-  ERL_NIF_TERM ref = enif_make_ref(vm->env);
+    // each call gets a unique ref
+    ERL_NIF_TERM ref = enif_make_ref(vm->env);
 
-  // prepare arguments
-  ERL_NIF_TERM *arr = (ERL_NIF_TERM *) malloc(sizeof(ERL_NIF_TERM) * 2);
-  arr[0] = js_to_term(vm->context, vm->isolate, vm->env, property);
-  arr[1] = js_to_term(vm->context, vm->isolate, vm->env, value);
-  ERL_NIF_TERM arglist = enif_make_list_from_array(vm->env,arr,2);
-  free(arr);
+    // prepare arguments
+    ERL_NIF_TERM *arr = (ERL_NIF_TERM *) malloc(sizeof(ERL_NIF_TERM) * 2);
+    arr[0] = js_to_term(vm->context, vm->isolate, vm->env, property);
+    arr[1] = js_to_term(vm->context, vm->isolate, vm->env, value);
+    ERL_NIF_TERM arglist = enif_make_list_from_array(vm->env,arr,2);
+    free(arr);
 
-  // send invocation request
-  SEND(vm->server,
-	   enif_make_tuple3(env,
-						enif_make_copy(env,external_to_term(data->GetHiddenValue(v8::String::New("_setter")))),
-						enif_make_tuple7(env, 
-										 enif_make_atom(env,"erlv8_fun_invocation"),
-										 enif_make_atom(env,"false"),
-										 js_to_term(vm->context, vm->isolate, env, info.Holder()),
-										 js_to_term(vm->context, vm->isolate, env, info.This()),
-										 enif_make_copy(env, ref),
-										 enif_make_pid(env, vm->server),
-										 enif_make_copy(env, external_to_term(v8::Context::GetCurrent()->Global()->GetHiddenValue(v8::String::New("__erlv8__ctx__"))))
-										 ),
-						enif_make_copy(env,arglist)));
-  vm->ticker(ref);  
+    // send invocation request
+    SEND(vm->server,
+         enif_make_tuple3(env,
+                          enif_make_copy(env,external_to_term(data->GetHiddenValue(v8::String::New("_setter")))),
+                          enif_make_tuple7(env,
+                                           enif_make_atom(env,"erlv8_fun_invocation"),
+                                           enif_make_atom(env,"false"),
+                                           js_to_term(vm->context, vm->isolate, env, info.Holder()),
+                                           js_to_term(vm->context, vm->isolate, env, info.This()),
+                                           enif_make_copy(env, ref),
+                                           enif_make_pid(env, vm->server),
+                                           enif_make_copy(env, external_to_term(v8::Context::GetCurrent()->Global()->GetHiddenValue(v8::String::New("__erlv8__ctx__"))))
+                                           ),
+                          enif_make_copy(env,arglist)));
+    vm->ticker(ref);
 }

--- a/c_src/erlv8_term.cc
+++ b/c_src/erlv8_term.cc
@@ -9,29 +9,29 @@ int enif_is_proplist(ErlNifEnv * env, ERL_NIF_TERM term)
   ErlNifBinary string_binary;
 
   if (!enif_is_list(env,term)) {
-	return 0;
+        return 0;
   }
   while (enif_get_list_cell(env, current, &head, &tail)) {
-	if (!enif_is_tuple(env,head)) return 0; // not a tuple -> not a proplist
-	enif_get_tuple(env,head,&arity,(const ERL_NIF_TERM **)&array);
-	if (arity != 2) return 0; // does not consist of two elements -> not a proplist
-	if (enif_is_list(env, array[0])) {
-	  unsigned len;
-	  enif_get_list_length(env, array[0], &len);
-	  char * str = (char *) malloc(len + 1);
-	  if (!enif_get_string(env, array[0], str, len + 1, ERL_NIF_LATIN1)) {
-		free(str);
-	 	return 0;
-	  }
-	  free(str);
-	} else if (!enif_is_atom(env, array[0])) {
+        if (!enif_is_tuple(env,head)) return 0; // not a tuple -> not a proplist
+        enif_get_tuple(env,head,&arity,(const ERL_NIF_TERM **)&array);
+        if (arity != 2) return 0; // does not consist of two elements -> not a proplist
+        if (enif_is_list(env, array[0])) {
+          unsigned len;
+          enif_get_list_length(env, array[0], &len);
+          char * str = (char *) malloc(len + 1);
+          if (!enif_get_string(env, array[0], str, len + 1, ERL_NIF_LATIN1)) {
+                free(str);
+                return 0;
+          }
+          free(str);
+        } else if (!enif_is_atom(env, array[0])) {
       if (enif_inspect_iolist_as_binary(env, array[0], &string_binary)) { // string
         return 1;
-      } 
-	  return 0;
-	}
+      }
+          return 0;
+        }
 
-	current = tail;
+        current = tail;
   }
   return 1;
 }
@@ -57,34 +57,34 @@ v8::PropertyAttribute term_to_property_attribute(ErlNifEnv * env, ERL_NIF_TERM t
     }
     return property_attribute;
   } else if (enif_is_list(env, term)) {
-	ERL_NIF_TERM current = term;
-	ERL_NIF_TERM head, tail;
-	v8::PropertyAttribute property_attribute = v8::None;
-	while (enif_get_list_cell(env, current, &head, &tail)) {
-	  property_attribute = (v8::PropertyAttribute) (property_attribute | term_to_property_attribute(env,head));
-	  current = tail;
-	}
-	return property_attribute;
+        ERL_NIF_TERM current = term;
+        ERL_NIF_TERM head, tail;
+        v8::PropertyAttribute property_attribute = v8::None;
+        while (enif_get_list_cell(env, current, &head, &tail)) {
+          property_attribute = (v8::PropertyAttribute) (property_attribute | term_to_property_attribute(env,head));
+          current = tail;
+        }
+        return property_attribute;
   } else {
-	return v8::None;
+        return v8::None;
   }
 }
 
 void weak_external_cleaner(v8::Persistent<v8::Value> object, void * data) {
   if (object.IsNearDeath()) {
-	term_ref_t * term_ref = (term_ref_t *) v8::External::Unwrap(v8::Handle<v8::External>::Cast(object));
-	enif_free_env(term_ref->env);
-	enif_free(term_ref);
+        term_ref_t * term_ref = (term_ref_t *) v8::External::Unwrap(v8::Handle<v8::External>::Cast(object));
+        enif_free_env(term_ref->env);
+        enif_free(term_ref);
     object.Dispose();
     object.Clear();
-	v8::V8::AdjustAmountOfExternalAllocatedMemory(-(long)sizeof(term_ref_t));
+        v8::V8::AdjustAmountOfExternalAllocatedMemory(-(long)sizeof(term_ref_t));
   }
 }
 
 inline v8::Handle<v8::Value> term_to_external(ERL_NIF_TERM term) {
   v8::HandleScope handle_scope;
-  term_ref_t * term_ref = (term_ref_t *) enif_alloc(sizeof(term_ref_t));	
-  term_ref->env = enif_alloc_env();										
+  term_ref_t * term_ref = (term_ref_t *) enif_alloc(sizeof(term_ref_t));
+  term_ref->env = enif_alloc_env();
   term_ref->term = enif_make_copy(term_ref->env, term);
   v8::Persistent<v8::External> obj = v8::Persistent<v8::External>::New(v8::External::New(term_ref));
   obj.MakeWeak(NULL,weak_external_cleaner);
@@ -93,14 +93,14 @@ inline v8::Handle<v8::Value> term_to_external(ERL_NIF_TERM term) {
 }
 
 inline ERL_NIF_TERM external_to_term(v8::Handle<v8::Value> val) {
-	term_ref_t * term_ref = (term_ref_t *) v8::External::Unwrap(v8::Handle<v8::External>::Cast(val));
-	return term_ref->term;
+        term_ref_t * term_ref = (term_ref_t *) v8::External::Unwrap(v8::Handle<v8::External>::Cast(val));
+        return term_ref->term;
 }
 
 v8::Handle<v8::Object> externalize_term(map<ERL_NIF_TERM, v8::Handle<v8::Object>, cmp_erl_nif_term> cache, v8::Handle<v8::Object> proto, ERL_NIF_TERM term) {
   v8::HandleScope handle_scope;
   map<ERL_NIF_TERM, v8::Handle<v8::Object>, cmp_erl_nif_term>::iterator iter = cache.find(term);
-  
+
   if (iter != cache.end()) {
     return handle_scope.Close(iter->second); // it was cached before
   } else {
@@ -115,16 +115,16 @@ v8::Handle<v8::Object> externalize_term(map<ERL_NIF_TERM, v8::Handle<v8::Object>
 }
 
 v8::Handle<v8::Value> term_to_js(v8::Handle<v8::Context> ctx,  v8::Isolate* isolate, ErlNifEnv *env, ERL_NIF_TERM term) {
-  TRACE("(%p) term_to_js - 1\n", isolate);  
+  TRACE("(%p) term_to_js - 1\n", isolate);
   LHCS(isolate, ctx);
-  TRACE("(%p) term_to_js - 2\n", isolate);  
+  TRACE("(%p) term_to_js - 2\n", isolate);
   int _int; unsigned int _uint; long _long; unsigned long _ulong; ErlNifSInt64 _int64; ErlNifUInt64 _uint64; double _double;
   ErlNifBinary string_binary;
   unsigned len;
   char name[MAX_ATOM_LEN];
-  
+
   if (enif_is_atom(env, term)) {
-    TRACE("(%p) term_to_js - 3 a\n", isolate);  
+    TRACE("(%p) term_to_js - 3 a\n", isolate);
     enif_get_atom_length(env, term, &len, ERL_NIF_LATIN1);
     enif_get_atom(env, term, (char *) &name,len + 1, ERL_NIF_LATIN1);
     v8::Handle<v8::Value> result;
@@ -144,25 +144,25 @@ v8::Handle<v8::Value> term_to_js(v8::Handle<v8::Context> ctx,  v8::Isolate* isol
     }
     return handle_scope.Close(result);
   } else if (enif_get_int(env,term,&_int)) {
-    TRACE("(%p) term_to_js - 3 b\n", isolate);  
+    TRACE("(%p) term_to_js - 3 b\n", isolate);
     return handle_scope.Close(v8::Local<v8::Integer>::New(v8::Integer::New(_int)));
   } else if (enif_get_uint(env,term,&_uint)) {
-    TRACE("(%p) term_to_js - 3 c\n", isolate);  
+    TRACE("(%p) term_to_js - 3 c\n", isolate);
     return handle_scope.Close(v8::Local<v8::Integer>::New(v8::Integer::NewFromUnsigned(_uint)));
   } else if (enif_get_long(env,term,&_long)) {
-    TRACE("(%p) term_to_js - 3 d\n", isolate);  
+    TRACE("(%p) term_to_js - 3 d\n", isolate);
     return handle_scope.Close(v8::Local<v8::Number>::New(v8::Number::New(_long)));
   } else if (enif_get_ulong(env,term,&_ulong)) {
-    TRACE("(%p) term_to_js - 3 e\n", isolate);  
+    TRACE("(%p) term_to_js - 3 e\n", isolate);
     return handle_scope.Close(v8::Local<v8::Number>::New(v8::Number::New(_ulong)));
   } else if (enif_get_int64(env,term,&_int64)) {
-    TRACE("(%p) term_to_js - 3 f\n", isolate);  
+    TRACE("(%p) term_to_js - 3 f\n", isolate);
     return handle_scope.Close(v8::Local<v8::Number>::New(v8::Number::New(_int64)));
   } else if (enif_get_uint64(env,term,&_uint64)) {
-    TRACE("(%p) term_to_js - 3 g\n", isolate);  
+    TRACE("(%p) term_to_js - 3 g\n", isolate);
     return handle_scope.Close(v8::Local<v8::Number>::New(v8::Number::New(_uint64)));
   } else if (enif_get_double(env,term,&_double)) {
-    TRACE("(%p) term_to_js - 3 h\n", isolate);  
+    TRACE("(%p) term_to_js - 3 h\n", isolate);
     return handle_scope.Close(v8::Local<v8::Number>::New(v8::Number::New(_double)));
   } else if (enif_inspect_iolist_as_binary(env, term, &string_binary)) { // string
     TRACE("(%p) term_to_js - 3 i\n", isolate);
@@ -171,11 +171,11 @@ v8::Handle<v8::Value> term_to_js(v8::Handle<v8::Context> ctx,  v8::Isolate* isol
       printf("%d != %lu\n", s->Utf8Length()-1, string_binary.size);
     return handle_scope.Close(s);
   } else if (enif_is_tuple(env, term)) {
-    TRACE("(%p) term_to_js - 3 j\n", isolate);  
+    TRACE("(%p) term_to_js - 3 j\n", isolate);
     ERL_NIF_TERM *array;
     int arity;
     enif_get_tuple(env,term,&arity,(const ERL_NIF_TERM **)&array);
-    if (arity == 3) { 
+    if (arity == 3) {
       enif_get_atom_length(env, array[0], &len, ERL_NIF_LATIN1);
       enif_get_atom(env,array[0], (char *) &name,len + 1, ERL_NIF_LATIN1);
       val_res_t *res;
@@ -185,91 +185,91 @@ v8::Handle<v8::Value> term_to_js(v8::Handle<v8::Context> ctx,  v8::Isolate* isol
       int isobj = strcmp(name,"erlv8_object")==0;
       // check if it is an array
       int isarray = strcmp(name,"erlv8_array")==0;
-      
+
       if (isobj||isarray) {
-	if (enif_get_resource(env,array[1],val_resource,(void **)(&res))) {
-	  return handle_scope.Close(res->val->ToObject());
-	} else if (isobj && enif_is_proplist(env,array[1])) {
-	  v8::Local<v8::Object> obj = v8::Object::New();
-	  ERL_NIF_TERM head, tail;
-	  ERL_NIF_TERM current = array[1];
-	  int arity;
-	  ERL_NIF_TERM *arr;
-	  while (enif_get_list_cell(env, current, &head, &tail)) {
-	    enif_get_tuple(env,head,&arity,(const ERL_NIF_TERM **)&arr);
-	    obj->Set(term_to_js(ctx, isolate, env,arr[0]),
-		     term_to_js(ctx, isolate, env,arr[1]));
-	    
-	    current = tail;
-	  }
-	  return handle_scope.Close(obj);
-	} else if (isarray && enif_is_list(env, array[1])) {
-	  unsigned int i,alen;
-	  ERL_NIF_TERM head, tail;
-	  ERL_NIF_TERM current = array[1];
-	  
-	  enif_get_list_length(env, current, &alen);
-	  
-	  v8::Local<v8::Array> arrobj = v8::Array::New(alen);
-	  
-	  i = 0;
-	  while (enif_get_list_cell(env, current, &head, &tail)) {
-	    arrobj->Set(v8::Integer::New(i), term_to_js(ctx, isolate, env,head));
-	    current = tail;
-	    i++;
-	  }
-	  return handle_scope.Close(arrobj);
-	}
+        if (enif_get_resource(env,array[1],val_resource,(void **)(&res))) {
+          return handle_scope.Close(res->val->ToObject());
+        } else if (isobj && enif_is_proplist(env,array[1])) {
+          v8::Local<v8::Object> obj = v8::Object::New();
+          ERL_NIF_TERM head, tail;
+          ERL_NIF_TERM current = array[1];
+          int arity;
+          ERL_NIF_TERM *arr;
+          while (enif_get_list_cell(env, current, &head, &tail)) {
+            enif_get_tuple(env,head,&arity,(const ERL_NIF_TERM **)&arr);
+            obj->Set(term_to_js(ctx, isolate, env,arr[0]),
+                     term_to_js(ctx, isolate, env,arr[1]));
+
+            current = tail;
+          }
+          return handle_scope.Close(obj);
+        } else if (isarray && enif_is_list(env, array[1])) {
+          unsigned int i,alen;
+          ERL_NIF_TERM head, tail;
+          ERL_NIF_TERM current = array[1];
+
+          enif_get_list_length(env, current, &alen);
+
+          v8::Local<v8::Array> arrobj = v8::Array::New(alen);
+
+          i = 0;
+          while (enif_get_list_cell(env, current, &head, &tail)) {
+            arrobj->Set(v8::Integer::New(i), term_to_js(ctx, isolate, env,head));
+            current = tail;
+            i++;
+          }
+          return handle_scope.Close(arrobj);
+        }
       }
-      
+
       if ((isv8fun) &&
-	  (enif_get_resource(env,array[1],val_resource,(void **)(&res)))){
-	return handle_scope.Close(res->val);
+          (enif_get_resource(env,array[1],val_resource,(void **)(&res)))){
+        return handle_scope.Close(res->val);
       } else if ((isv8fun) && (enif_is_fun(env, array[1]))) {
-	v8::Handle<v8::Function> f = v8::Handle<v8::Function>::Cast(term_to_js(ctx, isolate, env, array[1]));
-	v8::Handle<v8::Object> o = v8::Handle<v8::Object>::Cast(term_to_js(ctx, isolate, env, array[2]));
-	
-	v8::Local<v8::Array> keys = o->GetPropertyNames();
-	
-	for (unsigned int i=0;i<keys->Length();i++) {
-	  v8::Local<v8::Value> key = keys->Get(v8::Integer::New(i));
-	  f->Set(key,o->Get(key));
-	}
-	
-	return handle_scope.Close(f);
-	
+        v8::Handle<v8::Function> f = v8::Handle<v8::Function>::Cast(term_to_js(ctx, isolate, env, array[1]));
+        v8::Handle<v8::Object> o = v8::Handle<v8::Object>::Cast(term_to_js(ctx, isolate, env, array[2]));
+
+        v8::Local<v8::Array> keys = o->GetPropertyNames();
+
+        for (unsigned int i=0;i<keys->Length();i++) {
+          v8::Local<v8::Value> key = keys->Get(v8::Integer::New(i));
+          f->Set(key,o->Get(key));
+        }
+
+        return handle_scope.Close(f);
+
       }
-      
+
     }
-    
-    if (arity == 2) { 
+
+    if (arity == 2) {
       enif_get_atom_length(env, array[0], &len, ERL_NIF_LATIN1);
       enif_get_atom(env,array[0], (char *) &name,len + 1, ERL_NIF_LATIN1);
       // check if it is an error
       int iserror = strcmp(name,"error")==0;
       int isthrow = strcmp(name,"throw")==0;
       if (iserror) {
-	return handle_scope.Close(v8::Exception::Error(v8::Handle<v8::String>::Cast(term_to_js(ctx, isolate, env,array[1]))));
+        return handle_scope.Close(v8::Exception::Error(v8::Handle<v8::String>::Cast(term_to_js(ctx, isolate, env,array[1]))));
       }
       if (isthrow) {
-	return v8::ThrowException(term_to_js(ctx, isolate, env, array[1]));
+        return v8::ThrowException(term_to_js(ctx, isolate, env, array[1]));
       }
     }
-    
+
   } else if (enif_is_fun(env, term)) {
-    TRACE("(%p) term_to_js - 3 k\n", isolate);  
+    TRACE("(%p) term_to_js - 3 k\n", isolate);
     VM * vm = (VM *) v8::External::Unwrap(v8::Context::GetCurrent()->Global()->GetHiddenValue(v8::String::New("__erlv8__")));
     map<ERL_NIF_TERM, v8::Handle<v8::FunctionTemplate>, cmp_erl_nif_term>::iterator iter = vm->fun_map.find(term);
-    
+
     if (iter != vm->fun_map.end()) {
       return handle_scope.Close(iter->second->GetFunction()); // it was cached before
     } else {
       v8::Handle<v8::Value> external = term_to_external(term);
       v8::Persistent<v8::FunctionTemplate> t = v8::Persistent<v8::FunctionTemplate>::New(v8::FunctionTemplate::New(WrapFun,external));
-      
+
       v8::Local<v8::Function> f = t->GetFunction();
       f->SetHiddenValue(vm->string__erlv8__, external);
-      
+
       vm->fun_map.insert(std::pair<ERL_NIF_TERM, v8::Handle<v8::FunctionTemplate> >(external_to_term(external), t)); // cache it
       return handle_scope.Close(f);
     }
@@ -280,7 +280,7 @@ v8::Handle<v8::Value> term_to_js(v8::Handle<v8::Context> ctx,  v8::Isolate* isol
     VM * vm = (VM *) v8::External::Unwrap(v8::Context::GetCurrent()->Global()->GetHiddenValue(v8::String::New("__erlv8__")));
     return handle_scope.Close(externalize_term(vm->extern_map, vm->external_proto_ref, term));
   }
-  
+
   return v8::Undefined(); // if nothing else works, return undefined
 };
 
@@ -308,14 +308,14 @@ ERL_NIF_TERM js_to_term(v8::Handle<v8::Context> ctx,  v8::Isolate* isolate, ErlN
     resource_term = enif_make_resource(env, ptr);
     TRACE("(%p) js_to_term - 9\n", isolate);
     enif_release_resource(ptr);
-    TRACE("(%p) js_to_term - 10\n", isolate);    
+    TRACE("(%p) js_to_term - 10\n", isolate);
     VM * vm = (VM *) v8::External::Unwrap(v8::Context::GetCurrent()->Global()->GetHiddenValue(v8::String::New("__erlv8__")));
-    TRACE("(%p) js_to_term - 11\n", isolate);    
-    ERL_NIF_TERM term = enif_make_tuple3(env,enif_make_atom(env,"erlv8_fun"), 
-					 resource_term,
-					 enif_make_pid(env, vm->server));
-    TRACE("(%p) js_to_term - 11\n", isolate);    
-    
+    TRACE("(%p) js_to_term - 11\n", isolate);
+    ERL_NIF_TERM term = enif_make_tuple3(env,enif_make_atom(env,"erlv8_fun"),
+                                         resource_term,
+                                         enif_make_pid(env, vm->server));
+    TRACE("(%p) js_to_term - 11\n", isolate);
+
     return term;
   } else if	(val->IsUndefined()) {
     TRACE("(%p) js_to_term - 3 c\n", isolate);
@@ -334,12 +334,12 @@ ERL_NIF_TERM js_to_term(v8::Handle<v8::Context> ctx,  v8::Isolate* isolate, ErlN
     ErlNifBinary result_binary = {0};
     {
       /*      v8::Local<v8::String> S =  val->ToString();
-	      v8::String::Utf8Value  V = v8::String::Utf8Value(val->ToString());*/
+              v8::String::Utf8Value  V = v8::String::Utf8Value(val->ToString());*/
       /*      enif_alloc_binary(S->Utf8Length(), &result_binary);
-	      S->WriteUtf8((char *) result_binary.data, result_binary.size);*/
+              S->WriteUtf8((char *) result_binary.data, result_binary.size);*/
     }
     /*    enif_alloc_binary(v8::String::Utf8Value(val->ToString()).length(), &result_binary);
-	  (void)memcpy(result_binary.data, *v8::String::Utf8Value(val->ToString()), result_binary.size);*/
+          (void)memcpy(result_binary.data, *v8::String::Utf8Value(val->ToString()), result_binary.size);*/
 
     enif_alloc_binary(v8::String::Utf8Value(val).length(), &result_binary);
     (void)memcpy(result_binary.data, *v8::String::Utf8Value(val), result_binary.size);
@@ -348,10 +348,10 @@ ERL_NIF_TERM js_to_term(v8::Handle<v8::Context> ctx,  v8::Isolate* isolate, ErlN
     return enif_make_binary(env, &result_binary);
   } else if (val->IsInt32()) {
     TRACE("(%p) js_to_term - 3 f\n", isolate);
-	return enif_make_long(env,val->ToInt32()->Value());
+        return enif_make_long(env,val->ToInt32()->Value());
   } else if (val->IsUint32()) {
     TRACE("(%p) js_to_term - 3 g\n", isolate);
-	return enif_make_int64(env,val->ToUint32()->Value());
+        return enif_make_int64(env,val->ToUint32()->Value());
   } else if (val->IsNumber()) {
     TRACE("(%p) js_to_term - 3 h\n", isolate);
     double d = val->ToNumber()->Value();
@@ -370,19 +370,19 @@ ERL_NIF_TERM js_to_term(v8::Handle<v8::Context> ctx,  v8::Isolate* isolate, ErlN
     ptr->ctx = v8::Persistent<v8::Context>::New(v8::Context::GetCurrent());
     resource_term = enif_make_resource(env, ptr);
     enif_release_resource(ptr);
-    
+
     VM * vm = (VM *) v8::External::Unwrap(v8::Context::GetCurrent()->Global()->GetHiddenValue(v8::String::New("__erlv8__")));
     ERL_NIF_TERM term = enif_make_tuple3(env,
-					 enif_make_atom(env, "erlv8_array"),
-					 resource_term,
-					 enif_make_pid(env, vm->server)
-					 );
-    
+                                         enif_make_atom(env, "erlv8_array"),
+                                         resource_term,
+                                         enif_make_pid(env, vm->server)
+                                         );
+
     return term;
   } else if (val->IsObject()) {
     TRACE("(%p) js_to_term - 3 j\n", isolate);
     v8::Local<v8::Object> obj = val->ToObject();
-    TRACE("(%p) js_to_term - 4\n", isolate);    
+    TRACE("(%p) js_to_term - 4\n", isolate);
     v8::Local<v8::Context> c = v8::Context::GetCurrent();
     TRACE("(%p) js_to_term - 5\n", isolate);
     v8::Local<v8::Object> g = c->Global();
@@ -392,33 +392,33 @@ ERL_NIF_TERM js_to_term(v8::Handle<v8::Context> ctx,  v8::Isolate* isolate, ErlN
     VM * vm = (VM *) v8::External::Unwrap(v);
     TRACE("(%p) js_to_term - 8\n", isolate);
     if (obj->GetPrototype()->Equals(vm->external_proto_num) ||
-	obj->GetPrototype()->Equals(vm->external_proto_atom) ||
-	obj->GetPrototype()->Equals(vm->external_proto_bin) ||
-	obj->GetPrototype()->Equals(vm->external_proto_ref) ||
-	obj->GetPrototype()->Equals(vm->external_proto_fun) ||
-	obj->GetPrototype()->Equals(vm->external_proto_port) ||
-	obj->GetPrototype()->Equals(vm->external_proto_pid) ||
-	obj->GetPrototype()->Equals(vm->external_proto_tuple) ||
-	obj->GetPrototype()->Equals(vm->external_proto_list)) {
+        obj->GetPrototype()->Equals(vm->external_proto_atom) ||
+        obj->GetPrototype()->Equals(vm->external_proto_bin) ||
+        obj->GetPrototype()->Equals(vm->external_proto_ref) ||
+        obj->GetPrototype()->Equals(vm->external_proto_fun) ||
+        obj->GetPrototype()->Equals(vm->external_proto_port) ||
+        obj->GetPrototype()->Equals(vm->external_proto_pid) ||
+        obj->GetPrototype()->Equals(vm->external_proto_tuple) ||
+        obj->GetPrototype()->Equals(vm->external_proto_list)) {
       TRACE("(%p) js_to_term - 7\n", isolate);
       return enif_make_copy(env, external_to_term(v8::Handle<v8::External>::Cast(obj->GetHiddenValue(vm->string__erlv8__))));
     } else {
       TRACE("(%p) js_to_term - 3 k\n", isolate);
       ERL_NIF_TERM resource_term;
-      
+
       val_res_t *ptr;
       ptr = (val_res_t *)enif_alloc_resource(val_resource, sizeof(val_res_t));
       ptr->val = v8::Persistent<v8::Object>::New(v8::Handle<v8::Object>::Cast(val));
       ptr->ctx = v8::Persistent<v8::Context>::New(v8::Context::GetCurrent());
       resource_term = enif_make_resource(env, ptr);
       enif_release_resource(ptr);
-      
+
       ERL_NIF_TERM term = enif_make_tuple3(env,
-					   enif_make_atom(env, "erlv8_object"),
-					   resource_term,
-					   enif_make_pid(env, vm->server)
-					   );
-      
+                                           enif_make_atom(env, "erlv8_object"),
+                                           resource_term,
+                                           enif_make_pid(env, vm->server)
+                                           );
+
       return term;
     }
   } else {

--- a/include/erlv8.hrl
+++ b/include/erlv8.hrl
@@ -12,6 +12,7 @@
 
 -record(erlv8_object, { resource, vm }).
 -record(erlv8_fun, { resource, vm }).
--record(erlv8_array, { resource, vm }).
+-record(erlv8_array, {resource, %% or array()
+                      vm}). %% or proplist()
 
 		  

--- a/src/erlv8_array.erl
+++ b/src/erlv8_array.erl
@@ -1,39 +1,39 @@
 -module(erlv8_array,[Resource,VM]).
+
 -extends(erlv8_object).
+
 -export([list/0,object/0,new/1, length/0, push/1, unshift/1, delete/1]).
 
 list() ->
-	erlv8_vm:enqueue_tick(VM,{list,Resource}).
+    erlv8_vm:enqueue_tick(VM,{list,Resource}).
 
 object() ->
-	erlv8_object:new(Resource,VM).
+    erlv8_object:new(Resource,VM).
 
 new(O) ->
-	{erlv8_array, O, undefined}.
+    {erlv8_array, O, undefined}.
 
 length() ->
-	length(list()). %% TODO: I guess it will be more efficient if we had a NIF for that?
+    length(list()). %% TODO: I guess it will be more efficient if we had a NIF for that?
 
 push(Val) ->
-	M = {?BASE_MODULE, Resource, VM},
-	M:set_value(length(),Val).
+    M = {?BASE_MODULE, Resource, VM},
+    M:set_value(length(),Val).
 
 unshift(Val) ->
-	M = {?BASE_MODULE, Resource, VM},
-	L = length(),
-	lists:foreach(fun (I) ->
-						  M:set_value(L-I,M:get_value(L-I-1))
-				  end, lists:seq(0,L-1)),
-	M:set_value(0,Val).
+    M = {?BASE_MODULE, Resource, VM},
+    L = length(),
+    lists:foreach(fun (I) ->
+                          M:set_value(L-I,M:get_value(L-I-1))
+                  end, lists:seq(0,L-1)),
+    M:set_value(0,Val).
 
 delete(Index) ->
-	M = {?BASE_MODULE, Resource, VM},
-	L = length(),
-	V = M:get_value(Index),
-	lists:foreach(fun (I) ->
-						  M:set_value(I,M:get_value(I+1))
-				  end, lists:seq(Index,L-1)),
-	M:set_value(length,L-1),
-	V.
-	
-	
+    M = {?BASE_MODULE, Resource, VM},
+    L = length(),
+    V = M:get_value(Index),
+    lists:foreach(fun (I) ->
+                          M:set_value(I,M:get_value(I+1))
+                  end, lists:seq(Index,L-1)),
+    M:set_value(length,L-1),
+    V.

--- a/src/erlv8_array.erl
+++ b/src/erlv8_array.erl
@@ -1,7 +1,6 @@
 -module(erlv8_array).
 
--record(erlv8_array, {resource, %% or array()
-                      vm}). %% or proplist()
+-include("erlv8.hrl").
 
 -extends(erlv8_object).
 

--- a/src/erlv8_fun.erl
+++ b/src/erlv8_fun.erl
@@ -1,24 +1,26 @@
 -module(erlv8_fun,[Resource,VM]).
+
 -extends(erlv8_object).
+
 -export([call/0,call/1,call/2,instantiate/0, instantiate/1, object/0]).
 
 call() ->
-	call([]).
+    call([]).
 
 call({erlv8_object, _,_}=T) ->
-	call(T,[]);
+    call(T,[]);
 
 call(Args) when is_list(Args) ->
-	erlv8_vm:enqueue_tick(VM, {call, Resource, Args}).
+    erlv8_vm:enqueue_tick(VM, {call, Resource, Args}).
 
 call({erlv8_object, _,_}=This, Args) when is_list(Args) ->
-	erlv8_vm:enqueue_tick(VM, {call, Resource, Args, This}).
+    erlv8_vm:enqueue_tick(VM, {call, Resource, Args, This}).
 
 instantiate() ->
-	instantiate([]).
+    instantiate([]).
 
 instantiate(Args) when is_list(Args) ->
-	erlv8_vm:enqueue_tick(VM, {inst, Resource, Args}).
+    erlv8_vm:enqueue_tick(VM, {inst, Resource, Args}).
 
 object() ->
-	{erlv8_object, Resource, VM}.
+    {erlv8_object, Resource, VM}.

--- a/src/erlv8_fun.erl
+++ b/src/erlv8_fun.erl
@@ -1,7 +1,6 @@
 -module(erlv8_fun).
 
--record(erlv8_fun, {resource, %% or fun()
-                    vm}). %% or proplist()
+-include("erlv8.hrl").
 
 -extends(erlv8_object).
 

--- a/src/erlv8_fun.erl
+++ b/src/erlv8_fun.erl
@@ -1,26 +1,37 @@
--module(erlv8_fun,[Resource,VM]).
+-module(erlv8_fun).
+
+-record(erlv8_fun, {resource, %% or fun()
+                    vm}). %% or proplist()
 
 -extends(erlv8_object).
 
--export([call/0,call/1,call/2,instantiate/0, instantiate/1, object/0]).
+-export([call/1,call/2,call/3,instantiate/1, instantiate/2, object/1,
 
-call() ->
-    call([]).
+         new/1, new/2]).
 
-call({erlv8_object, _,_}=T) ->
-    call(T,[]);
+call(Self) ->
+    call([], Self).
 
-call(Args) when is_list(Args) ->
+call({erlv8_object, _,_}=T, Self) ->
+    call(T,[], Self);
+
+call(Args, #erlv8_fun{resource = Resource, vm = VM}) when is_list(Args) ->
     erlv8_vm:enqueue_tick(VM, {call, Resource, Args}).
 
-call({erlv8_object, _,_}=This, Args) when is_list(Args) ->
+call({erlv8_object, _,_}=This, Args, #erlv8_fun{resource = Resource, vm = VM}) when is_list(Args) ->
     erlv8_vm:enqueue_tick(VM, {call, Resource, Args, This}).
 
-instantiate() ->
-    instantiate([]).
+instantiate(Self) ->
+    instantiate([], Self).
 
-instantiate(Args) when is_list(Args) ->
+instantiate(Args, #erlv8_fun{resource = Resource, vm = VM}) when is_list(Args) ->
     erlv8_vm:enqueue_tick(VM, {inst, Resource, Args}).
 
-object() ->
+object(#erlv8_fun{resource = Resource, vm = VM}) ->
     {erlv8_object, Resource, VM}.
+
+new(O) ->
+    new(O,undefined).
+
+new(O, V) ->
+    #erlv8_fun{resource = O, vm = V}.

--- a/src/erlv8_object.erl
+++ b/src/erlv8_object.erl
@@ -1,6 +1,6 @@
 -module(erlv8_object).
 
--record(erlv8_object, {resource,vm}).
+-include("erlv8.hrl").
 
 -export([proplist/1, set_value/3, set_value/4, set_hidden_value/3, get_value/2, get_value/3, get_hidden_value/2, get_hidden_value/3,
          internal_field_count/1, get_internal_field/2, set_internal_field/3,

--- a/src/erlv8_object.erl
+++ b/src/erlv8_object.erl
@@ -1,108 +1,115 @@
--module(erlv8_object,[Resource,VM]).
--export([proplist/0, set_value/2, set_value/3, set_hidden_value/2, get_value/1, get_value/2, get_hidden_value/1, get_hidden_value/2, 
-		 internal_field_count/0, get_internal_field/1, set_internal_field/2,
-		 set_prototype/1, get_prototype/0, delete/1, set_accessor/2, set_accessor/3, set_accessor/4, set_accessor/5,
-		 equals/1, strict_equals/1, call/1, call/2,new/1]).
+-module(erlv8_object).
 
-proplist() ->
-	erlv8_vm:enqueue_tick(VM,{proplist, Resource}).
+-record(erlv8_object, {resource,vm}).
 
-set_value(Key,Value) ->
-	erlv8_vm:enqueue_tick(VM, {set, Resource, Key, Value}).
+-export([proplist/1, set_value/3, set_value/4, set_hidden_value/3, get_value/2, get_value/3, get_hidden_value/2, get_hidden_value/3,
+         internal_field_count/1, get_internal_field/2, set_internal_field/3,
+         set_prototype/2, get_prototype/1, delete/2, set_accessor/3, set_accessor/4, set_accessor/5, set_accessor/6,
+         equals/2, strict_equals/2, call/2, call/3,
 
-set_value(Key,Value,PropertyAttribute) ->
-	erlv8_vm:enqueue_tick(VM, {set, Resource, Key, Value, PropertyAttribute}).
+         new/1, new/2]).
 
-set_hidden_value(Key,Value) ->
-	erlv8_vm:enqueue_tick(VM, {set_hidden, Resource, Key, Value}).
+proplist({_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM,{proplist, Resource}).
 
-get_value(Key) ->
-	get_value(Key, undefined).
+set_value(Key, Value, {_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM, {set, Resource, Key, Value}).
 
-get_value(Key, Default) ->
-	case erlv8_vm:enqueue_tick(VM, {get, Resource, Key}) of
-		undefined ->
-			Default;
-		Val ->
-			Val
-	end.
+set_value(Key,Value,PropertyAttribute, {_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM, {set, Resource, Key, Value, PropertyAttribute}).
 
-get_hidden_value(Key) ->
-	get_hidden_value(Key, undefined).
+set_hidden_value(Key,Value, {_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM, {set_hidden, Resource, Key, Value}).
 
-get_hidden_value(Key, Default) ->
-	case erlv8_vm:enqueue_tick(VM, {get_hidden, Resource, Key}) of
-		undefined ->
-			Default;
-		Val ->
-			Val
-	end.
+get_value(Key, {_Erlv8Obj,  _Resource, _VM} = Self) ->
+    get_value(Key, undefined, Self).
 
-internal_field_count() ->
-	erlv8_vm:enqueue_tick(VM, {internal_count, Resource}).
+get_value(Key, Default, {_Erlv8Obj,  Resource, VM}) ->
+    case erlv8_vm:enqueue_tick(VM, {get, Resource, Key}) of
+        undefined ->
+            Default;
+        Val ->
+            Val
+    end.
 
-get_internal_field(Index) ->
-	erlv8_vm:enqueue_tick(VM, {get_internal, Resource, Index}).
+get_hidden_value(Key, {_Erlv8Obj,  _Resource, _VM} = Self) ->
+    get_hidden_value(Key, undefined, Self).
 
-set_internal_field(Index, {extern, Value}) ->
-	erlv8_vm:enqueue_tick(VM, {set_internal_extern, Resource, Index, Value, erlv8_extern:type(Value)});
+get_hidden_value(Key, Default, {_Erlv8Obj,  Resource, VM}) ->
+    case erlv8_vm:enqueue_tick(VM, {get_hidden, Resource, Key}) of
+        undefined ->
+            Default;
+        Val ->
+            Val
+    end.
 
-set_internal_field(Index, Value) ->
-	erlv8_vm:enqueue_tick(VM, {set_internal, Resource, Index, Value}).
+internal_field_count({_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM, {internal_count, Resource}).
 
-set_prototype(Proto) ->
+get_internal_field(Index, {_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM, {get_internal, Resource, Index}).
+
+set_internal_field(Index, {extern, Value}, {_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM, {set_internal_extern, Resource, Index, Value, erlv8_extern:type(Value)});
+
+set_internal_field(Index, Value, {_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM, {set_internal, Resource, Index, Value}).
+
+set_prototype(Proto, {_Erlv8Obj,  Resource, VM}) ->
     erlv8_vm:enqueue_tick(VM, {set_proto, Resource, Proto}).
 
-get_prototype() ->
-	erlv8_vm:enqueue_tick(VM, {get_proto, Resource}).
+get_prototype({_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM, {get_proto, Resource}).
 
-delete(Key) ->
-	erlv8_vm:enqueue_tick(VM, {delete, Resource, Key}).
+delete(Key, {_Erlv8Obj,  Resource, VM}) ->
+    erlv8_vm:enqueue_tick(VM, {delete, Resource, Key}).
 
-set_accessor(Property, Getter) ->
-	case erlv8_vm:enqueue_tick(VM, {set_accessor, Resource, Property, Getter}) of
+set_accessor(Property, Getter, {_Erlv8Obj,  Resource, VM}) ->
+    case erlv8_vm:enqueue_tick(VM, {set_accessor, Resource, Property, Getter}) of
         badarg ->
             throw(badarg);
         Result ->
             Result
     end.
 
-set_accessor(Property, Getter, Setter) ->
-	case erlv8_vm:enqueue_tick(VM, {set_accessor, Resource, Property, Getter, Setter}) of
+set_accessor(Property, Getter, Setter, {_Erlv8Obj,  Resource, VM}) ->
+    case erlv8_vm:enqueue_tick(VM, {set_accessor, Resource, Property, Getter, Setter}) of
         badarg ->
             throw(badarg);
         Result ->
             Result
     end.
 
-set_accessor(Property, Getter, Setter, AccessControl) ->
-	case erlv8_vm:enqueue_tick(VM, {set_accessor, Resource, Property, Getter, Setter, AccessControl}) of
+set_accessor(Property, Getter, Setter, AccessControl, {_Erlv8Obj,  Resource, VM}) ->
+    case erlv8_vm:enqueue_tick(VM, {set_accessor, Resource, Property, Getter, Setter, AccessControl}) of
         badarg ->
             throw(badarg);
         Result ->
             Result
     end.
 
-set_accessor(Property, Getter, Setter, AccessControl, PropertyAttribute) ->
-	case erlv8_vm:enqueue_tick(VM, {set_accessor, Resource, Property, Getter, Setter, AccessControl, PropertyAttribute}) of
+set_accessor(Property, Getter, Setter, AccessControl, PropertyAttribute, {_Erlv8Obj,  Resource, VM}) ->
+    case erlv8_vm:enqueue_tick(VM, {set_accessor, Resource, Property, Getter, Setter, AccessControl, PropertyAttribute}) of
         badarg ->
             throw(badarg);
         Result ->
             Result
     end.
 
-equals({_Tag,AnotherObject,_}) ->
-	erlv8_value:equals(VM, Resource, AnotherObject).
+equals({_Tag,AnotherObject,_}, {_Erlv8Obj,  Resource, VM}) ->
+    erlv8_value:equals(VM, Resource, AnotherObject).
 
-strict_equals({_Tag,AnotherObject,_}) ->
-	erlv8_value:strict_equals(VM, Resource, AnotherObject).
+strict_equals({_Tag,AnotherObject,_}, {_Erlv8Obj,  Resource, VM}) ->
+    erlv8_value:strict_equals(VM, Resource, AnotherObject).
 
-call(Fun) ->
-	call(Fun,[]).
+call(Fun, Self) ->
+    call(Fun,[], Self).
 
-call(Fun,Args) ->
+call(Fun,Args, {_Erlv8Obj,  Resource, VM}) ->
     Fun:call({erlv8_object, Resource,VM}, Args).
-	
+
 new(O) ->
-	instance(O,undefined).
-	
+    new(O,undefined).
+
+new(O, V) ->
+    #erlv8_object{resource = O, vm = V}.

--- a/src/erlv8_vm.erl
+++ b/src/erlv8_vm.erl
@@ -67,7 +67,9 @@ run_timed(Server, {C, CtxRes}, Source, {Name, LineOffset, ColumnOffset}, Timeout
 run(Server, {_, _CtxRes} = Context, Source) ->
 	run(Server, Context, Source, {"unknown",0,0}).
 
-run(Server, {_, CtxRes}, Source, {Name, LineOffset, ColumnOffset}) ->
+run(Server, A, Source, B) when is_binary(Source) ->
+    run(Server, A, binary_to_list(Source), B);
+run(Server, {_, CtxRes}, Source, {Name, LineOffset, ColumnOffset}) when is_list(Source) ->
 	enqueue_tick(Server, {script, CtxRes, Source, Name, LineOffset, ColumnOffset}).
 
 


### PR DESCRIPTION
Rewrite erlv8_{object,array,fun} to use module tuples instead of parametrized modules. Other changes which are included (and which you might not like :) ):
- reformat some C and some Erlang code to use only spaces
- handle running scripts both in string and in binary
- fail early on erlv8_vm:taint/2 input

If you don't like some of it, I'll refactor the pull request
